### PR TITLE
fea: Add Adapter pattern project

### DIFF
--- a/adapter/README.md
+++ b/adapter/README.md
@@ -1,0 +1,29 @@
+# Adapter Pattern Implementation
+
+This project demonstrates a simple implementation of the Adapter Pattern used in software design. The program consists of a `Client.java`, `OldService.java`, `NewInterface.java` and `Adapter.java` file.
+
+## Overview
+
+The Adapter Pattern is a design pattern that translates the interface for one class into a compatible interface. The idea is to allow classes to work together that couldn't otherwise due to incompatible interfaces.
+
+The project consists of four class files which implement this pattern:
+
+1. **`OldService`**: This represents an old, pre-existing service we want to use that does not match the interface we need for our new code.
+
+2. **`NewInterface`**: This is the interface that new requests are made on.
+
+3. **`Adapter`**: The Adapter imitates the behavior of another class. This is the class that connects the `NewInterface` and `OldService`.
+
+4. **`Client`**: This class represents new code/client which wants to use the new interface.
+
+## Running the Program
+
+Use a Java compiler to compile all four class files. The `main` method in `Client` class is the entry point to the program. Run this `main` method to run the entire program.
+
+You will see this output:
+
+`OldService runs oldRequest`
+
+This line of output demonstrates that we have successfully used the `OldService` through the `Adapter`, while the `Client` interacted with the `NewInterface`.
+
+Let me know if there's anything else you need help with in this project.

--- a/adapter/pom.xml
+++ b/adapter/pom.xml
@@ -3,22 +3,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.learning</groupId>
+        <artifactId>learning-java-design-patterns</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
 
-    <groupId>org.learning</groupId>
-    <artifactId>learning-java-design-patterns</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <modules>
-        <module>factory-method</module>
-        <module>singleton</module>
-        <module>abstract-factory</module>
-        <module>template-method</module>
-        <module>interpreter</module>
-        <module>ChainOfResponsibility</module>
-        <module>prototype</module>
-        <module>builder</module>
-        <module>adapter</module>
-    </modules>
+    <artifactId>adapter</artifactId>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/adapter/src/main/java/org/learning/Adapter.java
+++ b/adapter/src/main/java/org/learning/Adapter.java
@@ -1,0 +1,13 @@
+package org.learning;
+
+public class Adapter implements NewInterface {
+    private OldService oldService;
+
+    public Adapter(OldService oldService) {
+        this.oldService = oldService;
+    }
+
+    public String newRequest() {
+        return oldService.oldRequest();
+    }
+}

--- a/adapter/src/main/java/org/learning/Main.java
+++ b/adapter/src/main/java/org/learning/Main.java
@@ -1,0 +1,8 @@
+package org.learning;
+
+public class Main {
+    public static void main(String[] args) {
+        NewInterface newInterface = new Adapter(new OldService());
+        System.out.println(newInterface.newRequest());
+    }
+}

--- a/adapter/src/main/java/org/learning/NewInterface.java
+++ b/adapter/src/main/java/org/learning/NewInterface.java
@@ -1,0 +1,5 @@
+package org.learning;
+
+public interface NewInterface {
+    String newRequest();
+}

--- a/adapter/src/main/java/org/learning/OldService.java
+++ b/adapter/src/main/java/org/learning/OldService.java
@@ -1,0 +1,7 @@
+package org.learning;
+
+public class OldService {
+    public String oldRequest() {
+        return "OldService runs oldRequest";
+    }
+}


### PR DESCRIPTION
This commit includes an implementation of the Adapter Design Pattern. It consists of an existing 'OldService' that doesn't match the new interface that our client is using. To bridge this gap without changing existing code, an 'Adapter' is used. The adapter implements the new interface, and internally delegates tasks to the old service. This allows the old service to be interacted via the new interface, demonstrating the effectiveness of the Adapter Pattern in enabling interaction between two incompatible interfaces.